### PR TITLE
OPE-2342 Delete all references to Logentries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Logger for NodeJS
 
-This utility library implements our standard Bunyan + Logentries + Sentry configuration
+This utility library implements our standard Bunyan + Sentry configuration
 
 ## Requirements
 
@@ -18,7 +18,6 @@ npm install --save chpr-logger
 |--------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | LOGGER_NAME              | yes      | Sets the name of the logger.                                                                                                                                                      |
 | LOGGER_LEVEL             | yes      | Set the minimum level of logs.                                                                                                                                                    |
-| LOGENTRIES_TOKEN         | no       | Sets the Logentries stream. ([le_node](https://www.npmjs.com/package/le_node))                                                                                                    |
 | SENTRY_DSN               | no       | Sets the Sentry stream. ([bunyan-sentry-stream](https://www.npmjs.com/package/bunyan-sentry-stream))                                                                              |
 | USE_BUNYAN_PRETTY_STREAM | no       | Outputs the logs on stdout with the pretty formatting from Bunyan. Must be set to `true` to be active. ([bunyan-prettystream](https://www.npmjs.com/package/bunyan-prettystream)) |
 | LOGSTASH_HOST            | no       | Logstash host, if you want to configure a logstash stream                                                                                                                         |

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const bunyan = require('bunyan');
 const raven = require('raven');
 const sentryStream = require('bunyan-sentry-stream');
 const logstashStream = require('bunyan-logstash-tcp');
-const le = require('le_node');
 const PrettyStream = require('bunyan-prettystream');
 
 
@@ -26,14 +25,6 @@ if (process.env.USE_BUNYAN_PRETTY_STREAM === 'true') {
   config.streams.push({ type: 'raw', level: loggerLevel, stream: prettyStdOut });
 } else {
   config.streams.push({ level: loggerLevel, stream: process.stdout });
-}
-
-if (process.env.LOGENTRIES_TOKEN) {
-  config.streams.push(le.bunyanStream({
-    token: process.env.LOGENTRIES_TOKEN,
-    minLevel: loggerLevel,
-    withStack: true
-  }));
 }
 
 if (process.env.LOGSTASH_HOST) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chpr-logger",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Logger for NodeJS application stack",
   "main": "index.js",
   "directories": {
@@ -33,7 +33,6 @@
     "bunyan-logstash-tcp": "0.3.5",
     "bunyan-prettystream": "0.1.3",
     "bunyan-sentry-stream": "1.0.2",
-    "le_node": "1.3.1",
     "raven": "0.11.0"
   },
   "engines": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -28,7 +28,6 @@ describe('index.js', () => {
       process.env = {
         LOGGER_NAME: 'Test logger name',
         LOGGER_LEVEL: 'debug',
-        LOGENTRIES_TOKEN: '00000000-0000-0000-0000-000000000000',
         SENTRY_DSN: 'https://a:b@fake.com/12345'
       };
       logger = rewire('../index');
@@ -57,7 +56,6 @@ describe('index.js', () => {
       process.env = {
         LOGGER_NAME: 'Test logger name',
         LOGGER_LEVEL: 'debug',
-        LOGENTRIES_TOKEN: '00000000-0000-0000-0000-000000000000',
         SENTRY_DSN: 'https://a:b@fake.com/12345'
       };
       logger = rewire('../index');
@@ -189,14 +187,6 @@ describe('index.js', () => {
       expect(config.streams[0]).to.have.property('type', 'raw');
       expect(config.streams[0]).to.have.property('level', 'info');
       expect(config.streams[0].stream).to.be.instanceOf(PrettyStream);
-    });
-
-    it('should have sentry stream with LOGENTRIES_TOKEN set', () => {
-      process.env.LOGENTRIES_TOKEN = '00000000-0000-0000-0000-000000000000';
-      const config = reloadConfig();
-
-      expect(config.streams).to.have.lengthOf(2);
-      expect(config.streams[1].name).to.equal('logentries');
     });
 
     it('should have sentry stream with SENTRY_DSN set', () => {


### PR DESCRIPTION
### Jira issue

https://transcovo.atlassian.net/browse/OPE-2342

### Purpose of this PR

Delete all references, code and documentation to Logentries as the service has
been replaced with ELK.

### Configuration change

Delete all variables referencing Logentries.

### Checks

- [ ] Documentation of API routes is very clear, even for a newcomer
- [ ] Documentation of database model fields and indices are very clear, even for a newcomer
- [ ] Documentation of environment variables is very clear, even for a newcomer
- [ ] All relevant usecases of are tested
- [ ] These changes won't cause memory / CPU problems even if business grows by a factor of 100
- [ ] It's ok if these changes go to production and then are rolled-back


### Linked PRs:

- ...
