### PR TITLE
TECH Bump raven version to 2.2.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ if (process.env.LOGSTASH_HOST) {
 let client;
 if (process.env.SENTRY_DSN) {
   client = new raven.Client(process.env.SENTRY_DSN, { name: loggerName });
-  client.patchGlobal();
+  client.install();
   config.streams.push(sentryStream(client));
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chpr-logger",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Logger for NodeJS application stack",
   "main": "index.js",
   "directories": {
@@ -33,7 +33,7 @@
     "bunyan-logstash-tcp": "0.3.5",
     "bunyan-prettystream": "0.1.3",
     "bunyan-sentry-stream": "1.0.2",
-    "raven": "0.11.0"
+    "raven": "2.2.1"
   },
   "engines": {
     "node": "4.8.4"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -32,7 +32,7 @@ describe('index.js', () => {
       };
       logger = rewire('../index');
       expect(logger).to.have.property('ravenClient');
-      expect(logger.ravenClient).to.be.instanceof(raven.Client);
+      expect(logger.ravenClient).to.be.instanceof(raven.Client.super_);
       process.env = oldEnv;
     });
   });


### PR DESCRIPTION
This is required for security purpose and having last available features of Sentry such as environments

![selection_390](https://user-images.githubusercontent.com/886331/32887313-cb0f897e-cac3-11e7-8ba5-a7f6bc4e2a8b.png)
