### PR TITLE
TECH remove unused LOGSTASH_HOST condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ npm install --save chpr-logger
 | LOGGER_LEVEL             | yes      | Set the minimum level of logs.                                                                                                                                                    |
 | SENTRY_DSN               | no       | Sets the Sentry stream. ([bunyan-sentry-stream](https://www.npmjs.com/package/bunyan-sentry-stream))                                                                              |
 | USE_BUNYAN_PRETTY_STREAM | no       | Outputs the logs on stdout with the pretty formatting from Bunyan. Must be set to `true` to be active. ([bunyan-prettystream](https://www.npmjs.com/package/bunyan-prettystream)) |
-| LOGSTASH_HOST            | no       | Logstash host, if you want to configure a logstash stream                                                                                                                         |
-| LOGSTASH_PORT            | no       | Logstash port                                                                                                                         |
 
 ## Use
 

--- a/index.js
+++ b/index.js
@@ -3,9 +3,7 @@
 const bunyan = require('bunyan');
 const raven = require('raven');
 const sentryStream = require('bunyan-sentry-stream');
-const logstashStream = require('bunyan-logstash-tcp');
 const PrettyStream = require('bunyan-prettystream');
-
 
 const loggerLevel = process.env.LOGGER_LEVEL || 'info';
 const loggerName = process.env.LOGGER_NAME || 'Development logger';
@@ -25,16 +23,6 @@ if (process.env.USE_BUNYAN_PRETTY_STREAM === 'true') {
   config.streams.push({ type: 'raw', level: loggerLevel, stream: prettyStdOut });
 } else {
   config.streams.push({ level: loggerLevel, stream: process.stdout });
-}
-
-if (process.env.LOGSTASH_HOST) {
-  config.streams.push({
-    type: 'raw',
-    stream: logstashStream.createStream({
-      host: process.env.LOGSTASH_HOST,
-      port: parseInt(process.env.LOGSTASH_PORT || '5000', 10)
-    })
-  });
 }
 
 let client;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chpr-logger",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Logger for NodeJS application stack",
   "main": "index.js",
   "directories": {
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "bunyan": "1.8.1",
-    "bunyan-logstash-tcp": "0.3.5",
     "bunyan-prettystream": "0.1.3",
     "bunyan-sentry-stream": "1.0.2",
     "raven": "2.2.1"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,7 +9,6 @@ let logger = require('../index');
 
 const PrettyStream = require('bunyan-prettystream');
 const SentryStream = require('bunyan-sentry-stream').SentryStream;
-const LogstashStream = require('bunyan-logstash-tcp').LogstashStream;
 
 describe('index.js', () => {
   let oldStdoutWrite;
@@ -195,25 +194,6 @@ describe('index.js', () => {
 
       expect(config.streams).to.have.lengthOf(2);
       expect(config.streams[1].stream).to.be.instanceOf(SentryStream);
-    });
-
-    it('should have logstash stream on the default port', () => {
-      process.env.LOGSTASH_HOST = 'samplehost';
-      const config = reloadConfig();
-      expect(config.streams).to.have.lengthOf(2);
-      expect(config.streams[1].stream).to.be.instanceOf(LogstashStream);
-      expect(config.streams[1].stream).to.have.property('host', 'samplehost');
-      expect(config.streams[1].stream).to.have.property('port', 5000);
-    });
-
-    it('should have logstash stream on the specified port', () => {
-      process.env.LOGSTASH_HOST = 'samplehost';
-      process.env.LOGSTASH_PORT = '5001';
-      const config = reloadConfig();
-      expect(config.streams).to.have.lengthOf(2);
-      expect(config.streams[1].stream).to.be.instanceOf(LogstashStream);
-      expect(config.streams[1].stream).to.have.property('host', 'samplehost');
-      expect(config.streams[1].stream).to.have.property('port', 5001);
     });
   });
 });


### PR DESCRIPTION
The LOGSTASH_HOST variable is never set on our application because we use stdout to
send logs to kibana so we can remove this if condition.