### PR TITLE
TECH - Add Logger typeof to allow external lib declaration and usage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,11 @@
 
 /// <reference types="node" />
 
-import Logger = require('bunyan');
+import BaseLogger = require('bunyan');
 
-declare const logger: Logger;
+declare const logger: BaseLogger;
+declare namespace logger {
+    type Logger = typeof logger;
+}
+
 export = logger;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chpr-logger",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Logger for NodeJS application stack",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
The purpose here is having the type of `logger` be available outside of this module without having to use `type X = typeof logger`.

The problem we get is the exported instance of Bunyan logger because from their declaration file, it's kind of hard to use the Logger class by itself. Besides, their exported object is mutated to add extra variable... 