### PR TITLE
TECH Override standard error serializer

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const sentryStream = require('bunyan-sentry-stream');
 const PrettyStream = require('bunyan-prettystream');
 
 const SensitiveDataStream = require('./streams/sensitive-data');
+const serializers = require('./serializers');
 
 const defaultConfig = {
   logger: {
@@ -33,7 +34,7 @@ function init(config) {
     level: loggerLevel,
     streams: [],
     serializers: {
-      err: bunyan.stdSerializers.err,
+      err: serializers.err,
     },
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chpr-logger",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Logger for NodeJS application stack",
   "main": "index.js",
   "directories": {
@@ -10,6 +10,7 @@
     "prettier": "prettier -l index.js '{streams,test}/**/*.js'",
     "eslint": "eslint .",
     "lint": "npm run prettier && npm run eslint",
+    "mocha": "_mocha --exit",
     "coverage": "NODE_ENV=test nyc _mocha --exit",
     "test": "npm run lint && npm run coverage"
   },

--- a/serializers/err.js
+++ b/serializers/err.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const _ = require('lodash');
+const bunyan = require('bunyan');
+
+/**
+ * Serialize an Error object.
+ *
+ * Overrides the default bunyan error serializer, only adds in the result the
+ * error enumerable properties.
+ *
+ * @param {Error} error The error
+ * @returns {Object} The formatted error.
+ */
+function err(error) {
+  return _.assign(bunyan.stdSerializers.err(error), error);
+}
+
+module.exports = {
+  err,
+};

--- a/serializers/index.js
+++ b/serializers/index.js
@@ -1,0 +1,5 @@
+const { err } = require('./err');
+
+module.exports = {
+  err,
+};

--- a/test/serializers/err.test.js
+++ b/test/serializers/err.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const serializers = require('../../serializers');
+
+describe('Serializers', () => {
+  describe('err', () => {
+    it('should format correctly a standard error', () => {
+      const err = new Error('some test error');
+      const res = serializers.err(err);
+      expect(res).to.deep.equal({
+        message: 'some test error',
+        name: 'Error',
+        code: undefined,
+        signal: undefined,
+        stack: res.stack,
+      });
+      expect(res.stack).to.match(/^Error: some test error/);
+    });
+
+    it('should forward the additional fields for a custom error', () => {
+      const err = new Error('some test error');
+      err.someField = 'ok';
+      const res = serializers.err(err);
+      expect(res).to.deep.equal({
+        message: 'some test error',
+        name: 'Error',
+        code: undefined,
+        signal: undefined,
+        stack: res.stack,
+        someField: 'ok',
+      });
+      expect(res.stack).to.match(/^Error: some test error/);
+    });
+  });
+});


### PR DESCRIPTION
Adds the custom fields in the log

Overrides [this function](https://github.com/trentm/node-bunyan/blob/fe31b83e42d9c7f784e83fdcc528a7c76e0dacae/lib/bunyan.js#L1139)

Tested the result:
```node
const logger = require('./index');

const err = new Error('some error');
err.extra_field = 'extra_value';

logger.info({ err }, 'Some log message');
```
gives
```json
{"name":"Development logger","hostname":"TRFRLTA028.local","pid":76144,"level":30,"err":{"message":"some error","name":"Error","stack":"Error: some error\n    at Object.<anonymous> (/Users/louisledey/dev/chpr-logger/test.js:3:13)\n    at Module._compile (module.js:541:32)\n    at Object.Module._extensions..js (module.js:550:10)\n    at Module.load (module.js:456:32)\n    at tryModuleLoad (module.js:415:12)\n    at Function.Module._load (module.js:407:3)\n    at Function.Module.runMain (module.js:575:10)\n    at startup (node.js:159:18)\n    at node.js:444:3","extra_field":"extra_value"},"msg":"Some log message","time":"2019-01-03T16:35:16.912Z","v":0}
```