### PR TITLE
TECH bump bunyan to 1.8.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chpr-logger",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Logger for NodeJS application stack",
   "main": "index.js",
   "directories": {
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@types/bunyan": "1.8.4",
-    "bunyan": "1.8.1",
+    "bunyan": "1.8.12",
     "bunyan-prettystream": "0.1.3",
     "bunyan-sentry-stream": "1.2.1",
     "lodash": "4.17.11",


### PR DESCRIPTION
Bump bunyan to 1.8.12 to fix build error with dtrace on macOS X