### PR TITLE
[PLAT-639] Add credentials obfuscation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ values by `__SENSITIVE_DATA__` string. This feature is enabled by default but
 you can skip this (not recommanded) by setting the environment variable
 `LOGGER_USE_SENSITIVE_DATA_STREAM` to `false`.
 
+In addition, you can update the pattern on which to make the match with the
+environment variable `LOGGER_SENSITIVE_DATA_PATTERN`. Its value must represent
+a valid [capturing regular expression](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/RegExp#group_back).
+
 You also can add custom filter :
 ```
 const sensitiveDataFragment = '(pass|password)'; // Will obfuscate 'pass' and 'password' data
@@ -87,7 +91,7 @@ const newLogger = init({
 });
 ```
 
-Moreover, you can also add customize the way it replaces data :
+Moreover, you can add customize the way it replaces data :
 ```
 const sensitiveDataPattern = [
   {
@@ -103,6 +107,4 @@ const newLogger = init({
 });
 ```
 
-In addition, you can update the pattern on which to make the match with the
-environment variable `LOGGER_SENSITIVE_DATA_PATTERN`. Its value must represent
-a valid [capturing regular expression](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/RegExp#group_back).
+🚨 Process is synchronous, it means that `sensitiveDataPattern` can produce performance issues on large sizes.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,33 @@ values by `__SENSITIVE_DATA__` string. This feature is enabled by default but
 you can skip this (not recommanded) by setting the environment variable
 `LOGGER_USE_SENSITIVE_DATA_STREAM` to `false`.
 
+You also can add custom filter :
+```
+const sensitiveDataFragment = '(pass|password)'; // Will obfuscate 'pass' and 'password' data
+
+const newLogger = init({
+  logger: {
+    sensitiveDataFragment,
+  },
+});
+```
+
+Moreover, you can also add customize the way it replaces data :
+```
+const sensitiveDataPattern = [
+  {
+    regex: YOUR_NEW_REGEX,
+    substitute: SUBSTITUTION_CONTENT,
+  }
+]; // Will replace data matching with new regex by substitute content
+
+const newLogger = init({
+  logger: {
+    sensitiveDataPattern,
+  },
+});
+```
+
 In addition, you can update the pattern on which to make the match with the
 environment variable `LOGGER_SENSITIVE_DATA_PATTERN`. Its value must represent
 a valid [capturing regular expression](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/RegExp#group_back).

--- a/index.js
+++ b/index.js
@@ -49,7 +49,10 @@ function init(config) {
   } else if (finalConfig.logger.hideSensitiveData) {
     loggerConfig.streams.push({
       level: loggerLevel,
-      stream: new SensitiveDataStream(finalConfig.logger.sensitiveDataPattern),
+      stream: new SensitiveDataStream(
+        finalConfig.logger.sensitiveDataFragment,
+        finalConfig.logger.sensitiveDataPattern
+      ),
     });
   } else {
     loggerConfig.streams.push({ level: loggerLevel, stream: process.stdout });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chpr-logger",
-  "version": "3.2.0",
+  "version": "4.2.0",
   "description": "Logger for NodeJS application stack",
   "main": "index.js",
   "directories": {

--- a/streams/sensitive-data.js
+++ b/streams/sensitive-data.js
@@ -8,23 +8,16 @@ module.exports = class SensitiveDataStream {
     this.fragments = fragments || DEFAULT_SENSITIVE_DATA_FRAGMENTS;
     this.replacer = '__SENSITIVE_DATA__';
 
-    // If a pattern is provided
-    if (patterns.length) {
-      this.patterns = patterns;
-    } else {
-      // If no pattern provided, then add 2 default regexes
-      this.patterns = [
-        {
-          regex: new RegExp(`"${this.fragments}":"([^"]*)"`, 'ig'), // @Match "mdp":"My super password"
-          substitute: `"$1":"${this.replacer}"`,
-        },
-        {
-          regex: new RegExp(`${this.fragments}=([\\w-]*)`, 'ig'), // @Match mdp=My-super-password
-          substitute: `$1=${this.replacer}`,
-        },
-      ];
-    }
+    this.patterns = [
+      ...patterns,
+      {
+        // Default pattern
+        regex: new RegExp(`"${this.fragments}":"([^"]*)"`, 'ig'), // @Match "mdp":"My super password"
+        substitute: `"$1":"${this.replacer}"`,
+      },
+    ];
   }
+
   write(input) {
     let sanitized = input;
 

--- a/streams/sensitive-data.js
+++ b/streams/sensitive-data.js
@@ -4,12 +4,34 @@ const DEFAULT_SENSITIVE_DATA_FRAGMENTS =
   '(mdp|password|authorization|token|pwd|auth)';
 
 module.exports = class SensitiveDataStream {
-  constructor(fragments) {
+  constructor(fragments, patterns = []) {
     this.fragments = fragments || DEFAULT_SENSITIVE_DATA_FRAGMENTS;
-    this.pattern = new RegExp(`"${this.fragments}":"([^"]*)"`, 'ig');
+    this.replacer = '__SENSITIVE_DATA__';
+
+    // If a pattern is provided
+    if (patterns.length) {
+      this.patterns = patterns;
+    } else {
+      // If no pattern provided, then add 2 default regexes
+      this.patterns = [
+        {
+          regex: new RegExp(`"${this.fragments}":"([^"]*)"`, 'ig'), // @Match "mdp":"My super password"
+          substitute: `"$1":"${this.replacer}"`,
+        },
+        {
+          regex: new RegExp(`${this.fragments}=([\\w-]*)`, 'ig'), // @Match mdp=My-super-password
+          substitute: `$1=${this.replacer}`,
+        },
+      ];
+    }
   }
   write(input) {
-    const sanitized = input.replace(this.pattern, '"$1":"__SENSITIVE_DATA__"');
+    let sanitized = input;
+
+    // Apply replace on input looping through patterns array
+    for (let pattern of this.patterns) {
+      sanitized = sanitized.replace(pattern.regex, pattern.substitute);
+    }
 
     return process.stdout.write(sanitized);
   }


### PR DESCRIPTION
## Purpose of this PR
To be clean with sentry implementation, we need to obfuscate some critical information in logs such as `TOKEN=MY_TOKEN` or `"token": "My token"`.

### Changes
- New obfuscation mode has been added : for example `password=My-super-password` in `log.msg` is now obfuscated by default ;
- Parameters of `SensitiveDataStream` has changed : 
   - `fragments` -> Example : `(password|mdp)`;
   - `patterns` -> Example : `[{ regex: YOUR_REGEX, substitute: SUBSTITUTION_CONTENT }]`;
- Add the possibility to provide an "obfuscation config" to obfuscate whatever you want. To do this you need to use : 
```
const newLogger = init({
   logger: { sensitiveDataFragment, sensitiveDataPattern },
});
``` 
- Update documentation