### PR TITLE
OPE-10714 Use SENTRY_ENVIRONMENT instead of NODE_ENV to set Sentry Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ npm install --save chpr-logger
 | `LOGGER_NAME`              | yes      | Sets the name of the logger.                                                                                                                                                      |
 | `LOGGER_LEVEL`             | yes      | Set the minimum level of logs.                                                                                                                                                    |
 | `SENTRY_DSN`               | no       | Sets the Sentry stream. ([bunyan-sentry-stream](https://www.npmjs.com/package/bunyan-sentry-stream))                                                                              |
+| `SENTRY_ENVIRONMENT`       | no       | Sets the Sentry Environment.                                                                                                                                                      |
 | `USE_BUNYAN_PRETTY_STREAM` | no       | Outputs the logs on stdout with the pretty formatting from Bunyan. Must be set to `true` to be active. ([bunyan-prettystream](https://www.npmjs.com/package/bunyan-prettystream)) |
 | `LOGGER_USE_SENSITIVE_DATA_STREAM` | no       | Use the sensitive data stream to remove any possible sensitive data from the logs (enabled by default, `false` to use the `process.stdout` stream). |
 | `LOGGER_SENSITIVE_DATA_PATTERN` | no       | Pattern fragments to match sensitive keys (default is `(mdp|password|authorization|token|pwd|auth)`). |

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const defaultConfig = {
   sentry: {
     dsn: process.env.SENTRY_DSN,
     release: undefined,
-    environment: process.env.NODE_ENV || 'development',
+    environment: process.env.SENTRY_ENVIRONMENT || 'development',
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chpr-logger",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Logger for NodeJS application stack",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Using `NODE_ENV` was a mistake from the start. `NODE_ENV` should only be used to configure NodeJS.

`SENTRY_ENVIRONMENT` lets use configure different environments in Sentry using the same DSN.
